### PR TITLE
Updates for ECS retries. Closes #14 Closes #25 Closes #26

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "1.0"
 
 scalaVersion := "2.11.8"
 
-val cromwellV = "25-4ad380b-SNAP"
+val cromwellV = "25-bba4d26-SNAP"
 val betterFilesV = "2.16.0"
 
 val compilerSettings = List(

--- a/src/main/scala/cromwell/backend/impl/aws/AwsFinalizationActor.scala
+++ b/src/main/scala/cromwell/backend/impl/aws/AwsFinalizationActor.scala
@@ -39,7 +39,8 @@ case class AwsFinalizationActor(override val standardParams: StandardFinalizatio
       val delocalizationScript = workflowInputsDirectory.createTempFile("delocalization", ".sh").chmod(allPermissions)
       delocalizationScript.write(commands)
 
-      runTask(s"sh ${delocalizationScript.pathWithoutScheme}", AwsBackendActorFactory.AwsCliImage, MemorySize(4096, MemoryUnit.MiB), 1, awsAttributes)
+      runTask(s"sh ${delocalizationScript.pathWithoutScheme}", AwsBackendActorFactory.AwsCliImage,
+        MemorySize(awsAttributes.containerMemoryMib.toDouble, MemoryUnit.MiB), 1, awsAttributes)
     }
     super.afterAll()
   }

--- a/src/main/scala/cromwell/backend/impl/aws/AwsInitializationActor.scala
+++ b/src/main/scala/cromwell/backend/impl/aws/AwsInitializationActor.scala
@@ -31,7 +31,7 @@ class AwsInitializationActor(standardParams: StandardInitializationActorParams)
   override def runtimeAttributesBuilder: StandardValidatedRuntimeAttributesBuilder = {
     super.runtimeAttributesBuilder.withValidation(
       DockerValidation.instance,
-      MemoryValidation.withDefaultMemory(MemorySize(4, MemoryUnit.GiB)),
+      MemoryValidation.withDefaultMemory(MemorySize(awsAttributes.containerMemoryMib.toDouble, MemoryUnit.MiB)),
       CpuValidation.default
     )
   }
@@ -80,7 +80,8 @@ class AwsInitializationActor(standardParams: StandardInitializationActorParams)
       val localizationScript = workflowInputsDirectory.createTempFile("localization", ".sh").chmod(allPermissions)
       localizationScript.write(commands)
 
-      runTask(s"sh ${localizationScript.pathWithoutScheme}", AwsBackendActorFactory.AwsCliImage, MemorySize(4096, MemoryUnit.MiB), 1, awsAttributes)
+      runTask(s"sh ${localizationScript.pathWithoutScheme}", AwsBackendActorFactory.AwsCliImage,
+        MemorySize(awsAttributes.containerMemoryMib.toDouble, MemoryUnit.MiB), 1, awsAttributes)
       Option(initializationData)
     })
   }

--- a/src/main/scala/cromwell/backend/impl/aws/AwsNonFatalException.scala
+++ b/src/main/scala/cromwell/backend/impl/aws/AwsNonFatalException.scala
@@ -1,0 +1,3 @@
+package cromwell.backend.impl.aws
+
+class AwsNonFatalException(message: String, cause: Throwable = null) extends Exception(message, cause)


### PR DESCRIPTION
CPU was being passed to ECS as cores, not units per core.
Instead of hard coding 4g, the default for runtime attributes, initialization, and finalization memory values all use the config key `container-memory-mib`.
Retry running jobs when no hosts are available to run the task.
Execute & poll retries for the async actor don't block, while initialization and finalization still block.
If during an async run, a task exits due to a list of known hiccups (currently list at size 1), then retry.
Retries are initiated by throwing a new checked (aka non-Runtime) exception, `AwsNonFatalException`.
Bumped cromwell version to latest develop.